### PR TITLE
feat(ui): enhance timer progress bar with color change and pulse effect

### DIFF
--- a/app/assets/stylesheets/components/_user_answers.scss
+++ b/app/assets/stylesheets/components/_user_answers.scss
@@ -17,7 +17,6 @@
   padding: 30px 15px;
 }
 
-
 .progress-bar {
   text-align: center;
   font-size: 20px;
@@ -162,13 +161,52 @@
 }
 
 .quiz-toolbar {
+  width: 100%;
   border-radius: 25px;
-  background-color: white;
   padding: 15px;
   text-align: center;
-  max-width: 80%;
   margin: 0;
-  box-shadow: inset 0 4px 6px rgba(0, 0, 0, 0.1);
-  font-size: 25px;
+  font-size: 20px;
   font-weight: bold;
+}
+
+.progress {
+  position: relative;
+  height: 12px;
+  background: #eee;
+  border-radius: 999px;
+  overflow: hidden;
+  box-shadow: inset 0 1px 2px rgba(0, 0, 0, 0.1);
+  animation: pulse 1s ease-in-out infinite var(--delay, 7s);
+}
+
+.progress_bar {
+  height: 100%;
+  width: 100%;
+  transition: width .25s linear;
+  background: linear-gradient(90deg, #22c55e, #16a34a);
+  animation:
+  timerShrink var(--duration, 10s) linear forwards,
+  barColor 3s linear forwards var(--delay, 5s),
+  pulse 1s ease-in-out infinite var(--delay, 7s)
+}
+
+@keyframes timerShrink {
+  from { width: 100%; }
+  to { width: 0%; }
+}
+
+@keyframes barColor {
+  from { background: linear-gradient(90deg, #22c55e, #16a34a); }
+  to { background: linear-gradient(90deg, #ef4444, #dc2626);}
+}
+
+@keyframes pulse {
+  0%, 100% { transform: scaleY(1); filter: brightness(1) }
+  50% { transform: scaleY(1.2); filter: brightness(1.3)}
+}
+
+.time {
+  margin-left: 8px;
+  font-variant-numeric: tabular-nums;
 }

--- a/app/assets/stylesheets/pages/_quiz_result.scss
+++ b/app/assets/stylesheets/pages/_quiz_result.scss
@@ -19,8 +19,6 @@
   gap: 16px;
 }
 
-
-
 .results-card .stars {
   display: flex;
   justify-content: center;

--- a/app/javascript/controllers/question_response_controller.js
+++ b/app/javascript/controllers/question_response_controller.js
@@ -2,7 +2,7 @@ import { Controller } from "@hotwired/stimulus"
 
 // Connects to data-controller="question-response"
 export default class extends Controller {
-  static targets = ["timer", "answer", "question", "timerContainer"]
+  static targets = ["timer", "answer", "question", "timerContainer", "progressBar"]
   static values = { duration: Number }
 
   connect() {
@@ -10,22 +10,27 @@ export default class extends Controller {
     this.answerShown = false
     this.submitted = false
     this.autoSubmitting = false
-    this.remaining = this.durationValue || 10
+    this.total = this.durationValue || 10
+    this.remaining = this.total
     this.renderTimer()
     this.startTimer()
+    this.progressBarTarget.style.setProperty('--duration', `${this.total}s`);
     this.answerTarget.classList.add("result_container_hidden")
     this.timerContainerTarget.classList.remove("quiz-toolbar-hidden")
+    this.updateProgressA11y(0)
   }
   disconnect() {
      this.stopTimer()
   }
 
   startTimer() {
+    this.stopTimer()
     this.interval = setInterval(() => {
       this.remaining -= 1
       this.renderTimer()
 
       if (this.remaining <= 0) {
+        this.remaining = 0
         this.stopTimer()
         this.showAnswerAndSubmitLater()
       }
@@ -40,11 +45,25 @@ export default class extends Controller {
   }
 
   renderTimer() {
-    if (!this.hasTimerTarget) return
+    if (this.hasTimerTarget) {
     const s = Math.max(this.remaining, 0)
     const m = Math.floor(s / 60)
     const ss = String(s % 60).padStart(2, "0")
     this.timerTarget.textContent = `${m}:${ss}`
+  }
+
+    if (this.hasProgressBarTarget) {
+      const pct = Math.max(0, Math.min(100, (this.remaining / this.total) * 100))
+      this.progressBarTarget.style.width = pct + "%"
+      this.updateProgressA11y(pct)
+    }
+  }
+
+  updateProgressA11y(pct) {
+    const progressEl = this.progressBarTarget?.parentElement
+    if (progressEl && progressEl.getAttribute("role") === "progressbar") {
+      progressEl.setAttribute("aria-valuenow", Math.round(pct))
+    }
   }
 
   onSubmit(event) {

--- a/app/views/games/show.html.erb
+++ b/app/views/games/show.html.erb
@@ -16,6 +16,15 @@
     </div>
   </div>
   <div class="quiz-toolbar quiz-toolbar-hidden" data-question-response-target="timerContainer">
-    Temps restant : <span data-question-response-target="timer">--:--</span>
+    <div
+      class="progress"
+      role="progressbar"
+      aria-valuemin="0"
+      aria-valuemax="100"
+      aria-valuenow="0"
+      aria-label="Timer">
+      <div class="progress_bar" data-question-response-target="progressBar"></div>
+    </div>
+    <%# <span class="time" data-question-response-target="timer"></span> %>
   </div>
 </div>


### PR DESCRIPTION
- added CSS animation to switch bar color to red during last 3 seconds
- added pulse effect to emphasize urgency before timer ends
- simplified Stimulus controller to handle CSS-driven progress bar
- kept the JS part and commented out the HTML for possible rollback or future timer improvements