### PR TITLE
Modify stats front

### DIFF
--- a/app/assets/stylesheets/pages/_stats.scss
+++ b/app/assets/stylesheets/pages/_stats.scss
@@ -1,9 +1,7 @@
 .parent {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  grid-template-columns: repeat(3, 1fr);
   gap: 18px 22px;
-  align-items: start;
-  padding: 0 1rem;
 }
 
 .card {
@@ -33,14 +31,6 @@
 
 .all-stats p {
   font-weight: bold;
-}
-
-.global {
-    background-color: white;
-  border-radius: 12px;
-  padding: 0.5em;
-  margin-bottom: 0.5em;
-  box-shadow: 2px 6px 6px 0px rgba(0,0,0,0.2);
 }
 
 .card-content {

--- a/app/assets/stylesheets/pages/_stats.scss
+++ b/app/assets/stylesheets/pages/_stats.scss
@@ -5,27 +5,27 @@
 }
 
 .card {
-  padding: 1.5em;
-  height: fit-content;
+  padding: 1em;
+  height: auto;
   background-color: #FFEC99 !important;
   border-radius: 16px;
   box-shadow: 2px 6px 6px 0px rgba(0,0,0,0.2);
 }
 
 .card h2 {
-  margin-bottom: 0.8em;
   text-align: center;
   font-weight: bold;
 }
 
 .all-stats {
-  width: 50%;
-  margin: 0 auto;
-  margin-bottom: 1em;
-  text-align: center;
+  margin-top: 0.5em;
+  height: 30% !important;
+  width: 100% !important;
+  border: none !important;
+  border-radius: 16px !important;
 }
 
-.all-stats h1 {
+.all-stats h4 {
   font-weight: bold;
 }
 
@@ -34,13 +34,61 @@
 }
 
 .card-content {
-  background-color: white;
-  border-radius: 12px;
+  height: 80px;
+  background-color: #FFEC99;
   padding: 0.5em;
   margin-bottom: 0.5em;
-  box-shadow: 2px 6px 6px 0px rgba(0,0,0,0.2);
+  perspective: 1000px;
 }
 
 .card-content p {
   margin: 0;
+}
+
+.card-inner {
+  position: relative;
+  width: 100%;
+  height: 100%;
+  transition: transform 0.6s;
+  transform-style: preserve-3d;
+}
+
+.card-content:hover .card-inner {
+  transform: rotateX(180deg);
+}
+
+.card-front, .card-back {
+  position: absolute;
+  width: 100%;
+  height: 100%;
+  backface-visibility: hidden;
+  padding: 1rem;
+  border-radius: 10px;
+  background: white;
+  box-shadow: 0 4px 8px rgba(0,0,0,0.2);
+}
+
+.card-front {
+  z-index: 2;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}
+
+.fa-solid {
+  font-size: 32px;
+  line-height: 1;
+  vertical-align: middle;
+}
+
+.card-back {
+  transform: rotateX(180deg);
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+}
+
+.card-back p {
+  font-weight: bold;
 }

--- a/app/assets/stylesheets/pages/_stats.scss
+++ b/app/assets/stylesheets/pages/_stats.scss
@@ -1,19 +1,23 @@
 .parent {
-display: grid;
-grid-template-columns: repeat(3, 1fr);
-grid-column-gap: 20px;
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  gap: 18px 22px;
+  align-items: start;
+  padding: 0 1rem;
 }
 
 .card {
   padding: 1.5em;
   height: fit-content;
   background-color: #FFEC99 !important;
-  border-radius: 12px;
+  border-radius: 16px;
   box-shadow: 2px 6px 6px 0px rgba(0,0,0,0.2);
 }
 
 .card h2 {
   margin-bottom: 0.8em;
+  text-align: center;
+  font-weight: bold;
 }
 
 .all-stats {
@@ -21,6 +25,10 @@ grid-column-gap: 20px;
   margin: 0 auto;
   margin-bottom: 1em;
   text-align: center;
+}
+
+.all-stats h1 {
+  font-weight: bold;
 }
 
 .all-stats p {

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -12,7 +12,7 @@ class PagesController < ApplicationController
 
     @answers = @user.user_answers
     @correct = @answers.joins(:game_question).where(is_correct: true)
-    @incorrect = @answers.joins(:game_question).where(is_correct: false || nil)
+    @incorrect = @answers.joins(:game_question).where(is_correct: false)
 
     correct = @correct.count
     incorrect = @incorrect.count

--- a/app/views/pages/stats.html.erb
+++ b/app/views/pages/stats.html.erb
@@ -42,83 +42,160 @@
   </nav>
 </aside>
 
-  <div class="all-stats card">
-    <h1 class="title">Statistiques</h1>
-    <div class="global">
-      <p style="color: green">Bonnes réponses: <%= @correct.count %></p>
-      <p style="color: red">Mauvaises réponses: <%= @incorrect.count %></p>
-      <p>Pourcentage global: <%= number_to_percentage(@total_correct, precision: 0) %> de bonnes réponses</p>
-    </div>
-  </div>
+
 
 <div class="parent stats-container">
 
   <div class="cat-stats card">
     <h2>Catégorie</h2>
+
     <div class="card-content">
-      <div class="front"><h4>Drapeaux:</h4></div>
-      <div class="back">
-        <p>Nombre de bonnes réponses: <%=  @correct_in_cat_dp.count %></p>
-        <p><%= number_to_percentage(@total_correct_dp, precision: 0) %> de réussite</p>
+      <div class="card-inner">
+        <div class="card-front"><h4><i class="fa-solid fa-flag" style="color: #ff0000ff;"></i> </h4></div>
+        <div class="card-back">
+          <p>Bonnes réponses: <%=  @correct_in_cat_dp.count %></p>
+          <p><%= number_to_percentage(@total_correct_dp, precision: 0) %> de réussite</p>
+        </div>
       </div>
     </div>
+
     <div class="card-content">
-      <h4>Hydrographie et reliefs:</h4>
-      <p>Nombre de bonnes réponses: <%=  @correct_in_cat_hr.count %>, <%= number_to_percentage(@total_correct_hr, precision: 0) %> de réussite</p>
+      <div class="card-inner">
+        <div class="card-front"><h4><i class="fa-solid fa-globe" style="color: #0849b9ff;"></i></h4></div>
+        <div class="card-back">
+          <p>Bonnes réponses: <%=  @correct_in_cat_hr.count %></p>
+          <p><%= number_to_percentage(@total_correct_hr, precision: 0) %> de réussite</p>
+        </div>
+      </div>
     </div>
+
     <div class="card-content">
-      <h4>Géopolitique:</h4>
-      <p>Nombre de bonnes réponses: <%=  @correct_in_cat_gp.count %>, <%= number_to_percentage(@total_correct_gp, precision: 0) %> de réussite</p>
+      <div class="card-inner">
+        <div class="card-front"><h4><i class="fa-solid fa-landmark" style="color: #f8f409ff;"></i></h4></div>
+        <div class="card-back">
+          <p>Bonnes réponses: <%=  @correct_in_cat_gp.count %></p>
+          <p><%= number_to_percentage(@total_correct_gp, precision: 0) %> de réussite</p>
+        </div>
+      </div>
     </div>
+
     <div class="card-content">
-      <h4>Régions et villes du monde:</h4>
-      <p>Nombre de bonnes réponses: <%=  @correct_in_cat_rv.count %>, <%= number_to_percentage(@total_correct_rv, precision: 0) %> de réussite</p>
+      <div class="card-inner">
+        <div class="card-front"><h4><i class="fa-solid fa-city" style="color: #077451ff;"></i></h4></div>
+        <div class="card-back">
+          <p>Bonnes réponses: <%=  @correct_in_cat_rv.count %></p>
+          <p><%= number_to_percentage(@total_correct_rv, precision: 0) %> de réussite</p>
+        </div>
+      </div>
     </div>
+
     <div class="card-content">
-      <h4>Cultures:</h4>
-      <p>Nombre de bonnes réponses: <%=  @correct_in_cat_cl.count %>, <%= number_to_percentage(@total_correct_cl, precision: 0) %> de réussite</p>
+      <div class="card-inner">
+        <div class="card-front"><h4><i class="fa-solid fa-masks-theater" style="color: #c957a5ff;"></i></h4></div>
+        <div class="card-back">
+          <p>Bonnes réponses: <%=  @correct_in_cat_cl.count %></p>
+          <p><%= number_to_percentage(@total_correct_cl, precision: 0) %> de réussite</p>
+        </div>
+      </div>
     </div>
   </div>
 
   <div class="diff-stats card">
     <h2>Difficulté</h2>
+
     <div class="card-content">
-      <h4>Niveau facile:</h4>
-      <p>Nombre de bonnes réponses: <%=  @correct_in_dif_f.count %>, <%= number_to_percentage(@total_correct_dif_f, precision: 0) %> de réussite</p>
+      <div class="card-inner">
+        <div class="card-front"><h4><i class="fa-solid fa-leaf" style="color: #63E6BE;"></i></h4></div>
+        <div class="card-back">
+          <p>Bonnes réponses: <%=  @correct_in_dif_f.count %></p>
+          <p><%= number_to_percentage(@total_correct_dif_f, precision: 0) %> de réussite</p>
+        </div>
+      </div>
     </div>
+
     <div class="card-content">
-      <h4>Niveau intermédiaire:</h4>
-      <p>Nombre de bonnes réponses: <%=  @correct_in_dif_i.count %>, <%= number_to_percentage(@total_correct_dif_i, precision: 0) %> de réussite</p>
+      <div class="card-inner">
+        <div class="card-front"><h4><i class="fa-solid fa-fire" style="color: #FFA500;"></i></h4></div>
+        <div class="card-back">
+          <p>Bonnes réponses: <%=  @correct_in_dif_i.count %></p>
+          <p><%= number_to_percentage(@total_correct_dif_i, precision: 0) %> de réussite</p>
+        </div>
+      </div>
     </div>
+
     <div class="card-content">
-      <h4>Niveau difficile:</h4>
-      <p>Nombre de bonnes réponses: <%=  @correct_in_dif_d.count %>, <%= number_to_percentage(@total_correct_dif_d, precision: 0) %> de réussite</p>
+      <div class="card-inner">
+        <div class="card-front"><h4><i class="fa-solid fa-skull" style="color: #1d302a;"></i></h4></div>
+        <div class="card-back">
+          <p>Bonnes réponses: <%=  @correct_in_dif_d.count %></p>
+          <p><%= number_to_percentage(@total_correct_dif_d, precision: 0) %> de réussite</p>
+        </div>
+      </div>
+    </div>
+
+    <div class="all-stats card-content">
+      <div class="card-inner">
+        <div class="card-front"><h4>Résumé</h4></div>
+        <div class="card-back">
+          <p style="color: green">Bonnes réponses: <%= @correct.count %></p>
+          <p style="color: red">Mauvaises réponses: <%= @incorrect.count %></p>
+          <p><%= number_to_percentage(@total_correct, precision: 0) %> de bonnes réponses</p>
+        </div>
+      </div>
     </div>
   </div>
 
   <div class="reg-stats card">
     <h2>Région</h2>
+
     <div class="card-content">
-      <h4>Europe:</h4>
-      <p>Nombre de bonnes réponses: <%=  @correct_in_reg_eu.count %>, <%= number_to_percentage(@total_correct_reg_eu, precision: 0) %> de réussite</p>
+      <div class="card-inner">
+        <div class="card-front"><h4><i class="fa-solid fa-earth-europe" style="color: #0296ffff;"></i></h4></div>
+        <div class="card-back">
+          <p>Bonnes réponses: <%= @correct_in_reg_eu.count %></p>
+          <p><%= number_to_percentage(@total_correct_reg_eu, precision: 0) %> de réussite</p>
+        </div>
+      </div>
     </div>
+
     <div class="card-content">
-      <h4>Amérique:</h4>
-      <p>Nombre de bonnes réponses: <%=  @correct_in_reg_am.count %>, <%= number_to_percentage(@total_correct_reg_am, precision: 0) %> de réussite</p>
+      <div class="card-inner">
+        <div class="card-front"><h4><i class="fa-solid fa-earth-americas" style="color: #0296ffff;"></i></h4></div>
+        <div class="card-back">
+          <p>Bonnes réponses: <%=  @correct_in_reg_am.count %></p>
+          <p><%= number_to_percentage(@total_correct_reg_am, precision: 0) %> de réussite</p>
+        </div>
+      </div>
     </div>
+
     <div class="card-content">
-      <h4>Asie:</h4>
-      <p>Nombre de bonnes réponses: <%=  @correct_in_reg_as.count %>, <%= number_to_percentage(@total_correct_reg_as, precision: 0) %> de réussite</p>
+      <div class="card-inner">
+        <div class="card-front"><h4><i class="fa-solid fa-earth-asia" style="color: #0296ffff;"></i></h4></div>
+        <div class="card-back">
+          <p>Bonnes réponses: <%=  @correct_in_reg_as.count %></p>
+          <p><%= number_to_percentage(@total_correct_reg_as, precision: 0) %> de réussite</p>
+        </div>
+      </div>
     </div>
+
     <div class="card-content">
-      <h4>Afrique:</h4>
-      <p>Nombre de bonnes réponses: <%=  @correct_in_reg_af.count %>, <%= number_to_percentage(@total_correct_reg_af, precision: 0) %> de réussite</p>
+      <div class="card-inner">
+        <div class="card-front"><h4><i class="fa-solid fa-earth-africa" style="color: #0296ffff;"></i></h4></div>
+        <div class="card-back">
+          <p>Bonnes réponses: <%=  @correct_in_reg_af.count %></p>
+          <p><%= number_to_percentage(@total_correct_reg_af, precision: 0) %> de réussite</p>
+        </div>
+      </div>
     </div>
+
     <div class="card-content">
-      <h4>Océanie:</h4>
-      <p>Nombre de bonnes réponses: <%=  @correct_in_reg_oc.count %>, <%= number_to_percentage(@total_correct_reg_oc, precision: 0) %> de réussite</p>
+      <div class="card-inner">
+        <div class="card-front"><h4><i class="fa-solid fa-earth-oceania" style="color: #0296ffff;"></i></h4></div>
+        <div class="card-back">
+          <p>Bonnes réponses: <%=  @correct_in_reg_oc.count %></p>
+          <p><%= number_to_percentage(@total_correct_reg_oc, precision: 0) %> de réussite</p>
+        </div>
+      </div>
     </div>
   </div>
 </div>
-
-<%= console %>

--- a/app/views/pages/stats.html.erb
+++ b/app/views/pages/stats.html.erb
@@ -56,23 +56,23 @@
   <div class="cat-stats card">
     <h2>Catégorie</h2>
     <div class="card-content">
-      <h4>Drapeaux:</h4>
+      <h4><i class="fa-solid fa-flag" style="color: #1d302a;"></i></h4>
       <p>Bonnes réponses: <%=  @correct_in_cat_dp.count %>, <%= @total_correct_dp %>% de réussite</p>
     </div>
     <div class="card-content">
-      <h4>Hydrographie et reliefs:</h4>
+      <h4><i class="fa-solid fa-globe" style="color: #1d302a;"></i></h4>
       <p>Bonnes réponses: <%=  @correct_in_cat_hr.count %>, <%= @total_correct_hr %>% de réussite</p>
     </div>
     <div class="card-content">
-      <h4>Géopolitique:</h4>
+      <h4><i class="fa-solid fa-landmark" style="color: #1d302a;"></i></h4>
       <p>Bonnes réponses: <%=  @correct_in_cat_gp.count %>, <%= @total_correct_gp %>% de réussite</p>
     </div>
     <div class="card-content">
-      <h4>Régions et villes du monde:</h4>
+      <h4><i class="fa-solid fa-city" style="color: #1d302a;"></i></h4>
       <p>Bonnes réponses: <%=  @correct_in_cat_rv.count %>, <%= @total_correct_rv %>% de réussite</p>
     </div>
     <div class="card-content">
-      <h4>Cultures:</h4>
+      <h4><i class="fa-solid fa-masks-theater" style="color: #1d302a;"></i></h4>
       <p>Bonnes réponses: <%=  @correct_in_cat_cl.count %>, <%= @total_correct_cl %>% de réussite</p>
     </div>
   </div>
@@ -80,15 +80,15 @@
   <div class="diff-stats card">
     <h2>Difficulté</h2>
     <div class="card-content">
-      <h4>Niveau facile:</h4>
+      <h4><i class="fa-solid fa-leaf" style="color: #63E6BE;"></i></h4>
       <p>Bonnes réponses: <%=  @correct_in_dif_f.count %>, <%= @total_correct_dif_f %>% de réussite</p>
     </div>
     <div class="card-content">
-      <h4>Niveau intermédiaire:</h4>
+      <h4><i class="fa-solid fa-fire" style="color: #FFA500;"></i></h4>
       <p>Bonnes réponses: <%=  @correct_in_dif_i.count %>, <%= @total_correct_dif_i %>% de réussite</p>
     </div>
     <div class="card-content">
-      <h4>Niveau difficile:</h4>
+      <h4><i class="fa-solid fa-skull" style="color: #1d302a;"></i></h4>
       <p>Bonnes réponses: <%=  @correct_in_dif_d.count %>, <%= @total_correct_dif_d %>% de réussite</p>
     </div>
   </div>
@@ -96,23 +96,23 @@
   <div class="reg-stats card">
     <h2>Région</h2>
     <div class="card-content">
-      <h4>Europe:</h4>
+      <h4><i class="fa-solid fa-earth-europe" style="color: #1d302a;"></i></h4>
       <p>Bonnes réponses: <%=  @correct_in_reg_eu.count %>, <%= @total_correct_reg_eu %>% de réussite</p>
     </div>
     <div class="card-content">
-      <h4>Amérique:</h4>
+      <h4><i class="fa-solid fa-earth-americas" style="color: #1d302a;"></i></h4>
       <p>Bonnes réponses: <%=  @correct_in_reg_am.count %>, <%= @total_correct_reg_am %>% de réussite</p>
     </div>
     <div class="card-content">
-      <h4>Asie:</h4>
+      <h4><i class="fa-solid fa-earth-asia" style="color: #1d302a;"></i></h4>
       <p>Bonnes réponses: <%=  @correct_in_reg_as.count %>, <%= @total_correct_reg_as %>% de réussite</p>
     </div>
     <div class="card-content">
-      <h4>Afrique:</h4>
+      <h4><i class="fa-solid fa-earth-africa" style="color: #1d302a;"></i></h4>
       <p>Bonnes réponses: <%=  @correct_in_reg_af.count %>, <%= @total_correct_reg_af %>% de réussite</p>
     </div>
     <div class="card-content">
-      <h4>Océanie:</h4>
+      <h4><i class="fa-solid fa-earth-oceania" style="color: #1d302a;"></i></h4>
       <p>Bonnes réponses: <%=  @correct_in_reg_oc.count %>, <%= @total_correct_reg_oc %>% de réussite</p>
     </div>
   </div>

--- a/app/views/pages/stats.html.erb
+++ b/app/views/pages/stats.html.erb
@@ -47,7 +47,7 @@
     <div class="global">
       <p style="color: green">Bonnes réponses: <%= @correct.count %></p>
       <p style="color: red">Mauvaises réponses: <%= @incorrect.count %></p>
-      <p>Pourcentage global: <%= number_to_percentage(@total_correct, precision: 1) %> de bonnes réponses</p>
+      <p>Pourcentage global: <%= number_to_percentage(@total_correct, precision: 0) %> de bonnes réponses</p>
     </div>
   </div>
 
@@ -56,64 +56,69 @@
   <div class="cat-stats card">
     <h2>Catégorie</h2>
     <div class="card-content">
-      <h4><i class="fa-solid fa-flag" style="color: #1d302a;"></i></h4>
-      <p>Bonnes réponses: <%=  @correct_in_cat_dp.count %>, <%= @total_correct_dp %>% de réussite</p>
+      <div class="front"><h4>Drapeaux:</h4></div>
+      <div class="back">
+        <p>Nombre de bonnes réponses: <%=  @correct_in_cat_dp.count %></p>
+        <p><%= number_to_percentage(@total_correct_dp, precision: 0) %> de réussite</p>
+      </div>
     </div>
     <div class="card-content">
-      <h4><i class="fa-solid fa-globe" style="color: #1d302a;"></i></h4>
-      <p>Bonnes réponses: <%=  @correct_in_cat_hr.count %>, <%= @total_correct_hr %>% de réussite</p>
+      <h4>Hydrographie et reliefs:</h4>
+      <p>Nombre de bonnes réponses: <%=  @correct_in_cat_hr.count %>, <%= number_to_percentage(@total_correct_hr, precision: 0) %> de réussite</p>
     </div>
     <div class="card-content">
-      <h4><i class="fa-solid fa-landmark" style="color: #1d302a;"></i></h4>
-      <p>Bonnes réponses: <%=  @correct_in_cat_gp.count %>, <%= @total_correct_gp %>% de réussite</p>
+      <h4>Géopolitique:</h4>
+      <p>Nombre de bonnes réponses: <%=  @correct_in_cat_gp.count %>, <%= number_to_percentage(@total_correct_gp, precision: 0) %> de réussite</p>
     </div>
     <div class="card-content">
-      <h4><i class="fa-solid fa-city" style="color: #1d302a;"></i></h4>
-      <p>Bonnes réponses: <%=  @correct_in_cat_rv.count %>, <%= @total_correct_rv %>% de réussite</p>
+      <h4>Régions et villes du monde:</h4>
+      <p>Nombre de bonnes réponses: <%=  @correct_in_cat_rv.count %>, <%= number_to_percentage(@total_correct_rv, precision: 0) %> de réussite</p>
     </div>
     <div class="card-content">
-      <h4><i class="fa-solid fa-masks-theater" style="color: #1d302a;"></i></h4>
-      <p>Bonnes réponses: <%=  @correct_in_cat_cl.count %>, <%= @total_correct_cl %>% de réussite</p>
+      <h4>Cultures:</h4>
+      <p>Nombre de bonnes réponses: <%=  @correct_in_cat_cl.count %>, <%= number_to_percentage(@total_correct_cl, precision: 0) %> de réussite</p>
     </div>
   </div>
 
   <div class="diff-stats card">
     <h2>Difficulté</h2>
     <div class="card-content">
-      <h4><i class="fa-solid fa-leaf" style="color: #63E6BE;"></i></h4>
-      <p>Bonnes réponses: <%=  @correct_in_dif_f.count %>, <%= @total_correct_dif_f %>% de réussite</p>
+      <h4>Niveau facile:</h4>
+      <p>Nombre de bonnes réponses: <%=  @correct_in_dif_f.count %>, <%= number_to_percentage(@total_correct_dif_f, precision: 0) %> de réussite</p>
     </div>
     <div class="card-content">
-      <h4><i class="fa-solid fa-fire" style="color: #FFA500;"></i></h4>
-      <p>Bonnes réponses: <%=  @correct_in_dif_i.count %>, <%= @total_correct_dif_i %>% de réussite</p>
+      <h4>Niveau intermédiaire:</h4>
+      <p>Nombre de bonnes réponses: <%=  @correct_in_dif_i.count %>, <%= number_to_percentage(@total_correct_dif_i, precision: 0) %> de réussite</p>
     </div>
     <div class="card-content">
-      <h4><i class="fa-solid fa-skull" style="color: #1d302a;"></i></h4>
-      <p>Bonnes réponses: <%=  @correct_in_dif_d.count %>, <%= @total_correct_dif_d %>% de réussite</p>
+      <h4>Niveau difficile:</h4>
+      <p>Nombre de bonnes réponses: <%=  @correct_in_dif_d.count %>, <%= number_to_percentage(@total_correct_dif_d, precision: 0) %> de réussite</p>
     </div>
   </div>
 
   <div class="reg-stats card">
     <h2>Région</h2>
     <div class="card-content">
-      <h4><i class="fa-solid fa-earth-europe" style="color: #1d302a;"></i></h4>
-      <p>Bonnes réponses: <%=  @correct_in_reg_eu.count %>, <%= @total_correct_reg_eu %>% de réussite</p>
+      <h4>Europe:</h4>
+      <p>Nombre de bonnes réponses: <%=  @correct_in_reg_eu.count %>, <%= number_to_percentage(@total_correct_reg_eu, precision: 0) %> de réussite</p>
     </div>
     <div class="card-content">
-      <h4><i class="fa-solid fa-earth-americas" style="color: #1d302a;"></i></h4>
-      <p>Bonnes réponses: <%=  @correct_in_reg_am.count %>, <%= @total_correct_reg_am %>% de réussite</p>
+      <h4>Amérique:</h4>
+      <p>Nombre de bonnes réponses: <%=  @correct_in_reg_am.count %>, <%= number_to_percentage(@total_correct_reg_am, precision: 0) %> de réussite</p>
     </div>
     <div class="card-content">
-      <h4><i class="fa-solid fa-earth-asia" style="color: #1d302a;"></i></h4>
-      <p>Bonnes réponses: <%=  @correct_in_reg_as.count %>, <%= @total_correct_reg_as %>% de réussite</p>
+      <h4>Asie:</h4>
+      <p>Nombre de bonnes réponses: <%=  @correct_in_reg_as.count %>, <%= number_to_percentage(@total_correct_reg_as, precision: 0) %> de réussite</p>
     </div>
     <div class="card-content">
-      <h4><i class="fa-solid fa-earth-africa" style="color: #1d302a;"></i></h4>
-      <p>Bonnes réponses: <%=  @correct_in_reg_af.count %>, <%= @total_correct_reg_af %>% de réussite</p>
+      <h4>Afrique:</h4>
+      <p>Nombre de bonnes réponses: <%=  @correct_in_reg_af.count %>, <%= number_to_percentage(@total_correct_reg_af, precision: 0) %> de réussite</p>
     </div>
     <div class="card-content">
-      <h4><i class="fa-solid fa-earth-oceania" style="color: #1d302a;"></i></h4>
-      <p>Bonnes réponses: <%=  @correct_in_reg_oc.count %>, <%= @total_correct_reg_oc %>% de réussite</p>
+      <h4>Océanie:</h4>
+      <p>Nombre de bonnes réponses: <%=  @correct_in_reg_oc.count %>, <%= number_to_percentage(@total_correct_reg_oc, precision: 0) %> de réussite</p>
     </div>
   </div>
 </div>
+
+<%= console %>

--- a/app/views/pages/stats.html.erb
+++ b/app/views/pages/stats.html.erb
@@ -43,10 +43,10 @@
 </aside>
 
   <div class="all-stats card">
-    <h1 class="title">Statistiques globales</h1>
+    <h1 class="title">Statistiques</h1>
     <div class="global">
-      <p style="color: green">Nombre de bonnes réponses: <%= @correct.count %></p>
-      <p style="color: red">Nombre de mauvaises réponses: <%= @incorrect.count %></p>
+      <p style="color: green">Bonnes réponses: <%= @correct.count %></p>
+      <p style="color: red">Mauvaises réponses: <%= @incorrect.count %></p>
       <p>Pourcentage global: <%= number_to_percentage(@total_correct, precision: 1) %> de bonnes réponses</p>
     </div>
   </div>
@@ -54,66 +54,66 @@
 <div class="parent stats-container">
 
   <div class="cat-stats card">
-    <h2>Statistiques par catégorie</h2>
+    <h2>Catégorie</h2>
     <div class="card-content">
       <h4>Drapeaux:</h4>
-      <p>Nombre de bonnes réponses: <%=  @correct_in_cat_dp.count %>, <%= @total_correct_dp %>% de réussite</p>
+      <p>Bonnes réponses: <%=  @correct_in_cat_dp.count %>, <%= @total_correct_dp %>% de réussite</p>
     </div>
     <div class="card-content">
       <h4>Hydrographie et reliefs:</h4>
-      <p>Nombre de bonnes réponses: <%=  @correct_in_cat_hr.count %>, <%= @total_correct_hr %>% de réussite</p>
+      <p>Bonnes réponses: <%=  @correct_in_cat_hr.count %>, <%= @total_correct_hr %>% de réussite</p>
     </div>
     <div class="card-content">
       <h4>Géopolitique:</h4>
-      <p>Nombre de bonnes réponses: <%=  @correct_in_cat_gp.count %>, <%= @total_correct_gp %>% de réussite</p>
+      <p>Bonnes réponses: <%=  @correct_in_cat_gp.count %>, <%= @total_correct_gp %>% de réussite</p>
     </div>
     <div class="card-content">
       <h4>Régions et villes du monde:</h4>
-      <p>Nombre de bonnes réponses: <%=  @correct_in_cat_rv.count %>, <%= @total_correct_rv %>% de réussite</p>
+      <p>Bonnes réponses: <%=  @correct_in_cat_rv.count %>, <%= @total_correct_rv %>% de réussite</p>
     </div>
     <div class="card-content">
       <h4>Cultures:</h4>
-      <p>Nombre de bonnes réponses: <%=  @correct_in_cat_cl.count %>, <%= @total_correct_cl %>% de réussite</p>
+      <p>Bonnes réponses: <%=  @correct_in_cat_cl.count %>, <%= @total_correct_cl %>% de réussite</p>
     </div>
   </div>
 
   <div class="diff-stats card">
-    <h2>Statistiques par difficulté</h2>
+    <h2>Difficulté</h2>
     <div class="card-content">
       <h4>Niveau facile:</h4>
-      <p>Nombre de bonnes réponses: <%=  @correct_in_dif_f.count %>, <%= @total_correct_dif_f %>% de réussite</p>
+      <p>Bonnes réponses: <%=  @correct_in_dif_f.count %>, <%= @total_correct_dif_f %>% de réussite</p>
     </div>
     <div class="card-content">
       <h4>Niveau intermédiaire:</h4>
-      <p>Nombre de bonnes réponses: <%=  @correct_in_dif_i.count %>, <%= @total_correct_dif_i %>% de réussite</p>
+      <p>Bonnes réponses: <%=  @correct_in_dif_i.count %>, <%= @total_correct_dif_i %>% de réussite</p>
     </div>
     <div class="card-content">
       <h4>Niveau difficile:</h4>
-      <p>Nombre de bonnes réponses: <%=  @correct_in_dif_d.count %>, <%= @total_correct_dif_d %>% de réussite</p>
+      <p>Bonnes réponses: <%=  @correct_in_dif_d.count %>, <%= @total_correct_dif_d %>% de réussite</p>
     </div>
   </div>
 
   <div class="reg-stats card">
-    <h2>Statistiques par région</h2>
+    <h2>Région</h2>
     <div class="card-content">
       <h4>Europe:</h4>
-      <p>Nombre de bonnes réponses: <%=  @correct_in_reg_eu.count %>, <%= @total_correct_reg_eu %>% de réussite</p>
+      <p>Bonnes réponses: <%=  @correct_in_reg_eu.count %>, <%= @total_correct_reg_eu %>% de réussite</p>
     </div>
     <div class="card-content">
       <h4>Amérique:</h4>
-      <p>Nombre de bonnes réponses: <%=  @correct_in_reg_am.count %>, <%= @total_correct_reg_am %>% de réussite</p>
+      <p>Bonnes réponses: <%=  @correct_in_reg_am.count %>, <%= @total_correct_reg_am %>% de réussite</p>
     </div>
     <div class="card-content">
       <h4>Asie:</h4>
-      <p>Nombre de bonnes réponses: <%=  @correct_in_reg_as.count %>, <%= @total_correct_reg_as %>% de réussite</p>
+      <p>Bonnes réponses: <%=  @correct_in_reg_as.count %>, <%= @total_correct_reg_as %>% de réussite</p>
     </div>
     <div class="card-content">
       <h4>Afrique:</h4>
-      <p>Nombre de bonnes réponses: <%=  @correct_in_reg_af.count %>, <%= @total_correct_reg_af %>% de réussite</p>
+      <p>Bonnes réponses: <%=  @correct_in_reg_af.count %>, <%= @total_correct_reg_af %>% de réussite</p>
     </div>
     <div class="card-content">
       <h4>Océanie:</h4>
-      <p>Nombre de bonnes réponses: <%=  @correct_in_reg_oc.count %>, <%= @total_correct_reg_oc %>% de réussite</p>
+      <p>Bonnes réponses: <%=  @correct_in_reg_oc.count %>, <%= @total_correct_reg_oc %>% de réussite</p>
     </div>
   </div>
 </div>


### PR DESCRIPTION
Restructure stats page layout and improve cards

- Restructured the grid on the stats page  
- Replaced stacked text with flip cards  
- Added icons and colors on the front side of the cards, with stats displayed on the back  
- Fixed bug in stats calculations  
- Moved global summary inside a card to free up space for other elements 