### PR TITLE
Pull Request: Responsive style updates for .game_card

### DIFF
--- a/app/assets/stylesheets/pages/_games_create.scss
+++ b/app/assets/stylesheets/pages/_games_create.scss
@@ -138,3 +138,37 @@
 .disable {
   opacity: 0.6;
 }
+
+@media (max-width: 1366px) {
+  .game_card {
+  height: 80vh;
+  width: 450px;
+  }
+  .game_card p {
+    margin: 10px 10px 15px;
+  }
+  .game_card select {
+    margin: 0 8px;
+  }
+  #game_region {
+    margin: 0;
+  }
+}
+
+@media (max-width: 1280px) {
+  .game_card {
+    height: 80vh;
+    width: 450px;
+  }
+  .game_card p {
+    font-size: 20px;
+    margin: 10px;
+    text-underline-offset: 5px;
+  }
+  .game_card select {
+    margin: 8px;
+  }
+  #game_region {
+    margin: 0;
+  }
+}


### PR DESCRIPTION
Changes Made :

- Added rules for screens ≤ 1366px:
   - .game_card → set to 80vh height and 450px width.
   - Adjusted margins for paragraphs and <select>.
   - Reset margin for #game_region.
   - 
- Added rules for screens ≤ 1280px:
   - .game_card → same dimensions (80vh, 450px).
   - Paragraphs (p) → increased font size (20px), simplified margins, added text-underline-offset.
   - Adjusted margins for <select>.
   - Reset margin for #game_region.

Goal  :
Enhance the adaptability of .game_card on intermediate resolutions, providing better readability and spacing on desktop and large tablets.