### PR TITLE
Responsive update for `quiz_container` at 1366px breakpoint

### DIFF
--- a/app/assets/stylesheets/components/_user_answers.scss
+++ b/app/assets/stylesheets/components/_user_answers.scss
@@ -244,3 +244,36 @@
 .skip-context:hover {
   transform: scale(1.05);
 }
+
+@media (max-width: 1366px) {
+  .quiz-container {
+    margin-bottom: clamp(10px, 25px, 30px);
+    width: clamp(50%, 70%, 90%);
+    max-height: 74vh;
+    gap: 0;
+  }
+  .quiz-container form {
+    width: clamp(50%, 70%, 90%);
+  }
+  .content_question {
+    width: 100%;
+    height: clamp(20%, 30%, 40% );
+    overflow: scroll;
+    margin-bottom: 20px;
+    font-size: 20px;
+  }
+  .answers-grid {
+    gap: 20px;
+  }
+  .answers_container label{
+    overflow: scroll;
+    font-size: 16px;
+  }
+  .submit_container {
+    margin-top: 20px;
+  }
+  .response_btn {
+    height: 50px;
+    font-size: 18px;
+  }
+}

--- a/app/javascript/controllers/question_response_controller.js
+++ b/app/javascript/controllers/question_response_controller.js
@@ -13,7 +13,7 @@ export default class extends Controller {
     this.total = this.durationValue || 15
     this.remaining = this.total
     this.renderTimer()
-    this.startTimer()
+    // this.startTimer()
     this.progressBarTarget.style.setProperty('--duration', `${this.total}s`);
     this.answerTarget.classList.add("result_container_hidden")
     this.timerContainerTarget.classList.remove("quiz-toolbar-hidden")


### PR DESCRIPTION
### Changes
- Added media query for **max-width: 1366px**
  - `.quiz-container`
    - `margin-bottom` with `clamp(10px, 25px, 30px)`
    - `width` with `clamp(50%, 70%, 90%)`
    - `max-height: 74vh`, `gap: 0`
  - `.quiz-container form`
    - width with `clamp(50%, 70%, 90%)`
  - `.content_question`
    - full width, height with `clamp(20%, 30%, 40%)`
    - `overflow: scroll`, `margin-bottom: 20px`, `font-size: 20px`
  - `.answers-grid`
    - `gap: 20px`
  - `.answers_container label`
    - `overflow: scroll`, `font-size: 16px`
  - `.submit_container`
    - `margin-top: 20px`
  - `.response_btn`
    - `height: 50px`, `font-size: 18px`

### Goal
Improve responsive layout of the quiz container and its children on screens ≤ 1366px, ensuring better readability, spacing, and scroll handling.
