### PR TITLE
Responsive adjustments for `.parent` and `.card-back` at 1366px and 1280px

### DIFF
--- a/app/assets/stylesheets/pages/_stats.scss
+++ b/app/assets/stylesheets/pages/_stats.scss
@@ -130,3 +130,21 @@
 .card-back p {
   font-weight: bold;
 }
+
+@media (max-width: 1366px) {
+  .parent {
+    margin-top: 0
+  }
+  .card-back {
+    font-size: 12px;
+  }
+}
+
+@media (max-width: 1280px) {
+  .parent {
+    margin-left: 3%;
+  }
+  .card-back {
+    font-size: 10px;
+  }
+}


### PR DESCRIPTION
### Changes
- **max-width: 1366px**
  - `.parent`
    - `margin-top: 0`
  - `.card-back`
    - `font-size: 12px`

- **max-width: 1280px**
  - `.parent`
    - `margin-left: 3%`
  - `.card-back`
    - `font-size: 10px`

### Goal
Refine layout and typography for `.parent` and `.card-back` components on screens ≤ 1366px and ≤ 1280px, improving alignment and readability on medium-to-small desktop resolutions.
