### PR TITLE
## feat(ui): improve responsiveness of quiz & map pages on ultra-wide screens

### DIFF
--- a/app/assets/stylesheets/components/_user_answers.scss
+++ b/app/assets/stylesheets/components/_user_answers.scss
@@ -1,3 +1,12 @@
+
+body.games.show.games-show {
+  .home-map {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+  }
+}
+
 .quiz-container-hidden {
   display: none !important;
 }
@@ -245,6 +254,7 @@
   transform: scale(1.05);
 }
 
+
 @media (max-width: 1366px) {
   .quiz-container {
     margin-bottom: clamp(10px, 25px, 30px);
@@ -275,5 +285,56 @@
   .response_btn {
     height: 50px;
     font-size: 18px;
+  }
+}
+
+@media (min-width: 3340px) {
+  .quiz-container {
+    max-width: 90%;
+    height: clamp(35vh, 45vh, 50vh );
+  }
+  .progress-bar p {
+    font-size: 28px;
+  }
+  .question_title {
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    align-items: center;
+    gap: 15px;
+  }
+  .question_title p {
+    font-size: 24px;
+  }
+  .content_question.question_title {
+    max-width: 90%;
+    font-size: 30px;
+    margin-bottom: 24px;
+    overflow: scroll;
+  }
+  .answers_container {
+    height: 100px;
+    width: 300px;
+  }
+  .answers_container label {
+    font-size: 24px;
+    overflow: scroll;
+  }
+  .response_container{
+    margin-bottom: 30px;
+  }
+  .response_btn {
+    height: 80px;
+    width: 60%;
+    font-size: 24px;
+  }
+  .result_container {
+    height: 450px;
+    width: 850px;
+  }
+  .skip-context {
+    font-size: 20px;
+    height: 60px;
+    width: 40%;
   }
 }

--- a/app/assets/stylesheets/pages/_games_create.scss
+++ b/app/assets/stylesheets/pages/_games_create.scss
@@ -1,3 +1,12 @@
+
+body.games.new.games-new {
+  .home-map {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+  }
+}
+
 .game_card {
   height: 700px;
   width: 500px;
@@ -138,6 +147,7 @@
 .disable {
   opacity: 0.6;
 }
+
 
 @media (max-width: 1366px) {
   .game_card {

--- a/app/assets/stylesheets/pages/_home.scss
+++ b/app/assets/stylesheets/pages/_home.scss
@@ -31,6 +31,7 @@
   height: 75vh;
 }
 
+
 .home-content {
   position: fixed;
   top: 50%;
@@ -40,7 +41,6 @@
   text-align: center;
   width: 90vw;
 }
-
 
 .geo-title {
   font-size: 4.5rem;
@@ -105,7 +105,6 @@
   box-shadow: inset 0 2px 6px rgba(0,0,0,0.25);
 }
 
-
 .gb-btn-about {
   display: inline-flex;
   align-items: center;
@@ -128,4 +127,10 @@
   bottom: 44px;
   right: 44px;
   z-index: 10;
+}
+
+@media (min-width: 2560px) {
+  .home-map {
+    width: 65%;
+  }
 }

--- a/app/assets/stylesheets/pages/_score_display.scss
+++ b/app/assets/stylesheets/pages/_score_display.scss
@@ -1,3 +1,10 @@
+body.scores.show.scores-show {
+  .home-map {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+  }
+}
 .score-container {
   display: flex;
   gap: 30px;

--- a/app/javascript/controllers/question_response_controller.js
+++ b/app/javascript/controllers/question_response_controller.js
@@ -13,7 +13,7 @@ export default class extends Controller {
     this.total = this.durationValue || 15
     this.remaining = this.total
     this.renderTimer()
-    // this.startTimer()
+    this.startTimer()
     this.progressBarTarget.style.setProperty('--duration', `${this.total}s`);
     this.answerTarget.classList.add("result_container_hidden")
     this.timerContainerTarget.classList.remove("quiz-toolbar-hidden")

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -36,7 +36,7 @@
 
   </head>
 
-  <body>
+  <body class="<%= "#{controller_name} #{action_name} #{controller_name}-#{action_name}" %>">
   <% unless controller_name == "pages" && action_name != "home" %>
 
     <%=render "shared/navbar"%>


### PR DESCRIPTION
- Center `.home-map` on **games/show**, **games/new**, and **scores/show** pages (flex + justify/align center).  
- Add **@media (min-width: 3340px)** rules to optimize layout on ultra-wide displays:  
  - `.quiz-container`: `max-width: 90%`, `height: clamp(35vh, 45vh, 50vh)`.  
  - `.progress-bar p`: font size `28px`.  
  - `.question_title`: column layout with `gap: 15px`.  
  - `.question_title p`: font size `24px`.  
  - `.content_question.question_title`: `max-width: 90%`, `font-size: 30px`, `margin-bottom: 24px`, `overflow: scroll`.  
  - `.answers_container`: `100px × 300px`; labels `24px` + `overflow: scroll`.  
  - `.response_container`: `margin-bottom: 30px`.  
  - `.response_btn`: `80px` height, `60%` width, `font-size: 24px`.  
  - `.result_container`: `450px × 850px`.  
  - `.skip-context`: `font-size: 20px`, `60px` height, `40%` width.  
- Add **@media (min-width: 2560px)** breakpoint for `.home-map`: width set to **65%**.
-  Restarted the **timer** logic in `user_answers_controller`.
