### PR TITLE
Add Badge Awarding Service; Polish Score/Profile UI

### DIFF
--- a/app/assets/stylesheets/pages/_profile.scss
+++ b/app/assets/stylesheets/pages/_profile.scss
@@ -135,6 +135,7 @@
   grid-template-columns: repeat(3, var(--hex-w));
   gap: var(--hex-gap);
   justify-content: center;
+  align-items: center;
 }
 
 
@@ -273,6 +274,23 @@
   width: 35px;
   height: 35px;
   object-fit: contain;
+}
+
+.reward-count {
+  margin-top:10px;
+  width:100%;
+  height:40px;
+  background:linear-gradient(180deg, #deb887, #a0522d);
+  border:3px solid #5c3317;
+  color:#fff8dc;
+  font-weight:bold;
+  display:flex;
+  align-items:center;
+  justify-content:center;
+  position:relative;
+  clip-path:polygon(0 0, 100% 0, 100% 70%, 50% 100%, 0 70%);
+  box-shadow:inset 0 2px 4px rgba(0,0,0,0.2), 0 2px 6px rgba(0,0,0,0.25);
+  font-family: "Georgia", serif;
 }
 
 @media (max-width: 1366px) {

--- a/app/assets/stylesheets/pages/_score_display.scss
+++ b/app/assets/stylesheets/pages/_score_display.scss
@@ -395,8 +395,6 @@ body.scores.show.scores-show {
   background: linear-gradient(45deg, #ff6b6b, #e74c3c);
 }
 
-
-
 @keyframes gentle-bounce {
 
   0%,

--- a/app/assets/stylesheets/pages/_score_display.scss
+++ b/app/assets/stylesheets/pages/_score_display.scss
@@ -106,18 +106,17 @@ body.scores.show.scores-show {
   line-height: 1;
 }
 
-// .achv-ico:hover {
-//   transform: translateY(-2px);
-//   box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
-//   border: none;
-//   outline: none;
-// }
-// .score-display {
-//   background: white;
-//   border-radius: 12px;
-//   padding: 16px;
-//   box-shadow: inset 0 1px 3px rgba(0, 0, 0, 0.1);
-// }
+.achv-ico[data-badge="diamant"] i { color: #74C0FC }
+.achv-ico[data-badge="medaille-d-or"] i { color: #FFD43B }
+.achv-ico[data-badge="medaille-d-argent"] i { color: #757575ff }
+.achv-ico[data-badge="medaille-de-bronze"] i { color: #9a7f1fff }
+.achv-ico[data-badge="poop"] i { color:  #513c1f }
+.achv-ico[data-badge="montagnard"] i { color:  #017452}
+.achv-ico[data-badge="roi-de-la-colline"] i { color: #FF0000 }
+.achv-ico[data-badge="capitaliste"] i { color: #B197FC }
+.achv-ico[data-badge="diplomate"] i { color: #b10196ff }
+.achv-ico[data-badge="culturiste"] i { color: #74C0FC }
+.achv-ico[data-badge="serial-crotteur"] i { color: #7e702a }
 
 .score-display .score-text {
   font-size: 28px;

--- a/app/controllers/scores_controller.rb
+++ b/app/controllers/scores_controller.rb
@@ -1,5 +1,6 @@
 class ScoresController < ApplicationController
   def show
     @score = Score.find(params[:id])
+    @awarded_badges = current_user.badges.where(id: Array(flash[:awarded_badge_ids]))
   end
 end

--- a/app/controllers/user_answers_controller.rb
+++ b/app/controllers/user_answers_controller.rb
@@ -25,6 +25,8 @@ class UserAnswersController < ApplicationController
       end
 
       if @user_answer.game_question.order == 10
+        awarded = BadgeAwarder.award_for(@score)
+        flash[:awarded_badge_ids] = awarded.map(&:id)
         redirect_to game_score_path(@game, @score)
       else
         # new_question

--- a/app/services/badge_awarder.rb
+++ b/app/services/badge_awarder.rb
@@ -1,0 +1,103 @@
+class BadgeAwarder
+  def self.award_for(score)
+    new(score).call
+  end
+
+  def initialize(score)
+    @score = score
+    @user = score.user
+    @game = score.game
+  end
+
+  def call
+    percentage = compute_percentage
+    names = compute_badge_names(percentage, @game)
+    names.map { |name| create_badge(name) }
+  end
+
+  private
+
+  def compute_percentage
+    total = @game.game_questions.count
+    return 0 if total.zero?
+    ((@score.value.to_f / total) * 100).round
+  end
+
+  def compute_badge_names(percentage, game)
+    names = []
+
+    if percentage == 100
+        names << "Diamant"
+    elsif percentage >= 80
+        names << "Médaille d'or"
+    elsif percentage >= 60
+        names << "Médaille d'argent"
+    elsif percentage >= 30
+        names << "Médaille de bronze"
+    else
+        names << "Poop"
+    end
+
+    if percentage >= 80
+      case game.category
+      when "Hydrographie et reliefs"
+      names << "Montagnard"
+      when "Drapeaux"
+      names << "Roi de la colline"
+      when "Régions et villes du monde"
+      names << "Capitaliste"
+      when "Géopolitique"
+      names << "Diplomate"
+      when "Cultures"
+      names << "Culturiste"
+      end
+    end
+
+  failed_games = @user.scores.where("scores.value < ?", 3).count
+    names << "Serial Crotteur" if failed_games == 5
+
+    names
+
+  end
+
+  def create_badge(name)
+    @user.badges.create!(
+      name: name,
+      icon: icon_for(name),
+      description: description_for(name),
+      earned_at: Time.current
+    )
+  end
+
+  def icon_for(name)
+  {
+    "Diamant" => "fa-gem",
+    "Médaille d'or" => "fa-medal",
+    "Médaille d'argent" => "fa-medal",
+    "Médaille de bronze" => "fa-medal",
+    "Poop" => "fa-poo",
+    "Montagnard" => "fa-person-hiking",
+    "Roi de la colline" => "fa-flag",
+    "Capitaliste" => "fa-building-columns",
+    "Diplomate" => "fa-helmet-un",
+    "Culturiste" => "fa-language",
+    "Serial Crotteur" => "fa-poo-storm"
+  }[name]
+  end
+
+  def description_for(name)
+    {
+      "Diamant" => "100% de bonnes réponses",
+      "Médaille d'or" => "≥ 80% de bonnes réponses",
+      "Médaille d'argent" => "≥ 60% de bonnes réponses",
+      "Médaille de bronze" => "≥ 30% de bonnes réponses",
+      "Poop" => "< 30% de bonnes réponses",
+      "Montagnard" => "≥ 80% en Hydrographie et reliefs",
+      "Roi de la colline" => "≥ en Drapeaux",
+      "Capitaliste" => "≥ 80% en Régions et villes du monde",
+      "Diplomate" => "≥ en Géopolitique",
+      "Culturiste" => "≥ 80% en cultures",
+      "Serial Crotteur" => "5 echecs < 3 bonnes réponses"
+    }[name]
+  end
+end

--- a/app/views/pages/profile.html.erb
+++ b/app/views/pages/profile.html.erb
@@ -153,3 +153,5 @@
     </div>
   </div>
 </div>
+
+<%= console %>

--- a/app/views/pages/profile.html.erb
+++ b/app/views/pages/profile.html.erb
@@ -71,7 +71,7 @@
       <hr class="profile-sep">
 
       <ul class="profile-stats">
-        <li>Nombres de badges : -</li>
+        <li>Nombres de badges : <strong><%= current_user.badges.count %></strong> </li>
         <li>Ranking : -</li>
         <li>Evolution ranking (+ / -)</li>
       </ul>
@@ -82,76 +82,128 @@
 
   <div class="rewards-right">
   <div class="reward-grid">
-    <div class="reward-card" data-bs-toggle="tooltip" data-bs-placement="top"title="Tu as <%= current_user.badges.count %> diamant(s) - 100% de bonnes réponses">
-      <div class="reward-ico" >
-        <i class="fa-solid fa-gem" style="color: #0051f2ff;"></i>
+    <% badges_counts = current_user.badges.group(:name).count %>
+
+    <div class="reward">
+      <div class="reward-card" data-bs-toggle="tooltip" data-bs-placement="top"title="Tu as <%= badges_counts["Diamant"].to_i %> diamant(s) - 100% de bonnes réponses">
+        <div class="reward-ico" >
+          <i class="fa-solid fa-gem" style="color: #0051f2ff;"></i>
+        </div>
+      </div>
+      <div class="reward-count">
+        <p><%= badges_counts["Diamant"].to_i %></p>
       </div>
     </div>
 
-    <div class="reward-card"
-     data-bs-toggle="tooltip"
-     data-bs-placement="top"
-     title="Tu as <%= current_user.badges.count %> medaille(s) d'or - 80% de bonnes réponses">
-  <div class="reward-ico">
-    <i class="fa-solid fa-medal" style="color: #b89600ff;"></i>
+    <div class="reward">
+      <div class="reward-card" data-bs-toggle="tooltip" data-bs-placement="top" title="Tu as <%= badges_counts["Médaille d'or"].to_i %> medaille(s) d'or - 80% de bonnes réponses">
+        <div class="reward-ico">
+          <i class="fa-solid fa-medal" style="color: #b89600ff;"></i>
+        </div>
+      </div>
+      <div class="reward-count">
+        <p><%= badges_counts["Médaille d'or"].to_i %></p>
+      </div>
+    </div>
+
+    <div class="reward">
+      <div class="reward-card" data-bs-toggle="tooltip" data-bs-placement="top" title="Tu as <%= badges_counts["Médaille d'argent"].to_i %> medaille(s) d'argent - 60% de bonnes réponses">
+        <div class="reward-ico">
+         <i class="fa-solid fa-medal" style="color: #858585ff;"></i>
+        </div>
+      </div>
+      <div class="reward-count">
+        <p><%= badges_counts["Médaille d'argent"].to_i %></p>
+      </div>
+    </div>
+
+    <div class="reward">
+      <div class="reward-card" data-bs-toggle="tooltip" data-bs-placement="top" title="Tu as <%= badges_counts["Médaille de bronze"].to_i %> medaille(s) de bronze - 30 % de bonnes réponses">
+        <div class="reward-ico">
+          <i class="fa-solid fa-medal" style="color: #fc8a1fff;"></i>
+        </div>
+      </div>
+      <div class="reward-count">
+        <p><%= badges_counts["Médaille de bronze"].to_i %></p>
+      </div>
+    </div>
+
+    <div class="reward">
+      <div class="reward-card" data-bs-toggle="tooltip" data-bs-placement="top" title="Tu as <%= badges_counts["Poo"].to_i %> medaille(s) pooh - Moins de 30% de bonnes réponse">
+        <div class="reward-ico">
+          <i class="fa-solid fa-poo" style="color: #6e4500ff;"></i>
+        </div>
+      </div>
+      <div class="reward-count">
+        <p><%= badges_counts["Poo"].to_i %></p>
+      </div>
+    </div>
+
+    <div class="reward">
+      <div class="reward-card" data-bs-toggle="tooltip" data-bs-placement="top" title="Tu as <%= badges_counts["Montagnard"].to_i %> badge(s) MONTAGNARD: 80% dans la catégorie Reliefs">
+        <div class="reward-ico">
+         <i class="fa-solid fa-person-hiking" style="color: #017452;"></i>
+        </div>
+      </div>
+      <div class="reward-count">
+        <p><%= badges_counts["Montagnard"].to_i %></p>
+      </div>
+    </div>
+
+    <div class="reward">
+      <div class="reward-card" data-bs-toggle="tooltip" data-bs-placement="top" title="Tu as <%= badges_counts["Roi de la colline"].to_i %> badge(s) ROI DE LA COLLINE: 80% dans la catégorie Drapeaux">
+        <div class="reward-ico">
+          <i class="fa-solid fa-flag" style="color: #ff0000;"></i>
+        </div>
+      </div>
+      <div class="reward-count">
+        <p><%= badges_counts["Roi de la colline"].to_i %></p>
+      </div>
+    </div>
+
+    <div class="reward">
+      <div class="reward-card" data-bs-toggle="tooltip" data-bs-placement="top" title="Tu as <%= badges_counts["Capitaliste"].to_i %> badge(s) CAPITALISTE: 80% dans la catégorie Capitales">
+        <div class="reward-ico">
+          <i class="fa-solid fa-building-columns" style="color: #B197FC;"></i>
+        </div>
+      </div>
+      <div class="reward-count">
+        <p><%= badges_counts["Capitaliste"].to_i %></p>
+      </div>
+    </div>
+
+    <div class="reward">
+      <div class="reward-card" data-bs-toggle="tooltip" data-bs-placement="top" title="Tu as <%= current_user.badges.count %> badge(s) CULTURISTE: 80% dans la catégorie Cultures">
+        <div class="reward-ico">
+          <i class="fa-solid fa-language" style="color: black"></i>
+        </div>
+      </div>
+      <div class="reward-count">
+        <p><%= badges_counts["Culturiste"].to_i %></p>
+      </div>
+    </div>
+
+    <div class="reward">
+      <div class="reward-card" data-bs-toggle="tooltip" data-bs-placement="top" title="Tu as <%= badges_counts["Diplomate"].to_i %> badge(s) DIPLOMATE: 80% dans la catégorie Géopolitique">
+        <div class="reward-ico">
+          <i class="fa-solid fa-helmet-un" style="color: #b10196ff;"></i>
+        </div>
+      </div>
+      <div class="reward-count">
+        <p><%= badges_counts["Diplomate"].to_i %></p>
+      </div>
+    </div>
+
+    <div class="reward">
+      <div class="reward-card" data-bs-toggle="tooltip" data-bs-placement="top" title="Tu as <%= badges_counts["Serial Crotteur"].to_i %> badge(s) SERIAL CROTTEUR: Tu as échoué 5 fois ou plus ">
+        <div class="reward-ico">
+          <i class="fa-solid fa-poo" style="color: #2b1b00ff;"></i>
+        </div>
+      </div>
+      <div class="reward-count">
+        <p><%= badges_counts["Serial Crotteur"].to_i %></p>
+      </div>
+    </div>
+
   </div>
 </div>
-
-    <div class="reward-card" data-bs-toggle="tooltip" data-bs-placement="top" title="Tu as <%= current_user.badges.count %> medaille(s) d'argent - 60% de bonnes réponses">
-      <div class="reward-ico">
-       <i class="fa-solid fa-medal" style="color: #858585ff;"></i>
-      </div>
-    </div>
-
-    <div class="reward-card" data-bs-toggle="tooltip" data-bs-placement="top" title="Tu as 1 medaille(s) de bronze - 30 % de bonnes réponses">
-      <div class="reward-ico">
-        <i class="fa-solid fa-medal" style="color: #fc8a1fff;"></i>
-      </div>
-    </div>
-
-    <div class="reward-card" data-bs-toggle="tooltip" data-bs-placement="top" title="Tu as <%= current_user.badges.count %> medaille(s) pooh - Moins de 30% de bonnes réponse">
-      <div class="reward-ico">
-        <i class="fa-solid fa-poo" style="color: #6e4500ff;"></i>
-      </div>
-    </div>
-
-    <div class="reward-card" data-bs-toggle="tooltip" data-bs-placement="top" title="Tu as <%= current_user.badges.count %> badge(s) MONTAGNARD: 80% dans la catégorie Reliefs">
-      <div class="reward-ico">
-       <i class="fa-solid fa-person-hiking" style="color: #017452;"></i>
-      </div>
-    </div>
-
-    <div class="reward-card" data-bs-toggle="tooltip" data-bs-placement="top" title="Tu as <%= current_user.badges.count %> badge(s) ROI DE LA COLLINE: 80% dans la catégorie Drapeaux">
-      <div class="reward-ico">
-        <i class="fa-solid fa-flag" style="color: #ff0000;"></i>
-      </div>
-    </div>
-
-    <div class="reward-card" data-bs-toggle="tooltip" data-bs-placement="top" title="Tu as <%= current_user.badges.count %> badge(s) CAPITALISTE: 80% dans la catégorie Capitales">
-      <div class="reward-ico">
-        <i class="fa-solid fa-building-columns" style="color: #B197FC;"></i>
-      </div>
-    </div>
-
-    <div class="reward-card" data-bs-toggle="tooltip" data-bs-placement="top" title="Tu as <%= current_user.badges.count %> badge(s) CULTURISTE: 80% dans la catégorie Cultures">
-      <div class="reward-ico">
-        <i class="fa-solid fa-language" style="color: black"></i>
-      </div>
-    </div>
-
-    <div class="reward-card" data-bs-toggle="tooltip" data-bs-placement="top" title="Tu as <%= current_user.badges.count %> badge(s) DIPLOMATE: 80% dans la catégorie Géopolitique">
-      <div class="reward-ico">
-        <i class="fa-solid fa-helmet-un" style="color: #b10196ff;"></i>
-      </div>
-
-    </div>
-
-    <div class="reward-card" data-bs-toggle="tooltip" data-bs-placement="top" title="Tu as <%= current_user.badges.count %> badge(s) SERIAL CROTTEUR: Tu as échoué 5 fois ou plus ">
-      <div class="reward-ico">
-        <i class="fa-solid fa-poo" style="color: #2b1b00ff;"></i>
-      </div>
-    </div>
-  </div>
-</div>
-
-<%= console %>

--- a/app/views/scores/show.html.erb
+++ b/app/views/scores/show.html.erb
@@ -25,74 +25,19 @@
             </div>
         </div>
             <h1 class="score-message" data-score-results-target="message"></h1>
-        <%
-            # Calcule badges obtenus quiz
-            earned_badges = []
 
-            # Badges de perf
-            if percentage == 100
-                earned_badges << "Diamant"
-            elsif percentage >= 80
-                earned_badges << "Médaille d'or"
-            elsif percentage >= 60
-                earned_badges << "Médaille d'argent"
-            elsif percentage >= 30
-                earned_badges << "Médaille de bronze"
-            else
-                earned_badges << "Poop"
-            end
-
-            # Badges thématiques
-            if percentage >= 80
-                case game.category
-                when "Hydrographie et reliefs"
-                earned_badges << "Montagnard"
-                when "Drapeaux"
-                earned_badges << "Roi de la colline"
-                when "Régions et villes du monde"
-                earned_badges << "Capitaliste"
-                when "Géopolitique"
-                earned_badges << "Diplomate"
-                when "Cultures"
-                earned_badges << "Culturiste"
-                end
-            end
-
-            # Badge Serial Crotteur (si applicable)
-            failed_games = current_user.scores.joins(:game).where("scores.value < ?", 3).count
-            if failed_games == 5
-                earned_badges << "Serial Crotteur"
-            end
-        %>
        <div class="badges-obtains">
-            <p>Badges obtenus</p>
+          <p>Badges obtenus</p>
             <div class="badges-icons">
-                <% earned_badges.each do |badge_name| %>
-                    <span class="achv-ico" title="<%= badge_name %>">
-                        <% case badge_name %>
-                        <% when "Diamant" %>
-                            <i class="fa-solid fa-gem" style="color: #74C0FC;"></i>
-                        <% when "Médaille d'or" %>
-                            <i class="fa-solid fa-medal" style="color: #FFD43B;"></i>
-                        <% when "Médaille d'argent" %>
-                            <i class="fa-solid fa-medal" style="color: #757575ff;"></i>
-                        <% when "Médaille de bronze" %>
-                            <i class="fa-solid fa-medal" style="color: #9a7f1fff;"></i>
-                        <% when "Poop" %>
-                            <i class="fa-solid fa-poo" style="color: #513c1f;"></i>
-                        <% when "Montagnard" %>
-                            <i class="fa-solid fa-person-hiking" style="color: #017452;"></i>
-                        <% when "Roi de la colline" %>
-                            <i class="fa-solid fa-flag" style="color: #FF0000;"></i>
-                        <% when "Capitaliste" %>
-                            <i class="fa-solid fa-building-columns" style="color: #B197FC;"></i>
-                        <% when "Diplomate" %>
-                            <i class="fa-solid fa-helmet-un" style="color: #b10196ff;"></i>
-                        <% when "Culturiste" %>
-                            <i class="fa-solid fa-language"></i>
-                        <% end %>
-                    </span>
+              <% if @awarded_badges.present? %>
+                <% @awarded_badges.each do |badge| %>
+                  <span class="achv-ico" data-badge="<%= badge.name.parameterize%>" title="<%= badge.name %>">
+                    <i class="fa-solid <%= badge.icon %>"></i>
+                  </span>
                 <% end %>
+              <% else %>
+                <span class="no-badge">Aucun badge gagné cette partie</span>
+              <% end %>
             </div>
         </div>
 


### PR DESCRIPTION
> # Add Badge Awarding Service; Polish Score/Profile UI

  ## Summary

  Introduces BadgeAwarder service and wires it into the game flow to award badges at the end of
  a run; surfaces awarded badges on the score page; refines profile and score styles.

  ## Changes

  - Service: app/services/badge_awarder.rb to compute/create badges by percentage and category.
  - Controllers: integrate flow in UserAnswersController#create; load awarded badges in
  ScoresController#show.
  - Views: display awarded badges in app/views/scores/show.html.erb; show badge counts in app/
  views/pages/profile.html.erb.
  - Styles: update app/assets/stylesheets/pages/_score_display.scss and app/assets/stylesheets/
  pages/_profile.scss.

  ## Why

  - Decouple badge logic from controllers, improve UX by surfacing achievements, and align UI
  with design.

  ## How to Test

  - Finish a game; confirm badges appear on the score page.
  - Verify profile shows per-badge counts and totals.
  - Hit ≥80% in each category to trigger category badges.
  - Simulate 5 failures (<3 correct) to see “Serial Crotteur”.
  - Check responsiveness and visual states across common breakpoints.

  ## Notes

  - No migrations; relies on existing Badge model.
  - Watch naming consistency for the “Poop/Poo” badge between service, views, and CSS.