### PR TITLE
Auth UI Refresh and Profile Editing Enhancements

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -18,3 +18,4 @@
 @import "pages/stats";
 @import "pages/score_display";
 @import "pages/about";
+@import "pages/registration";

--- a/app/assets/stylesheets/pages/_registration.scss
+++ b/app/assets/stylesheets/pages/_registration.scss
@@ -1,0 +1,62 @@
+body.registrations.new.registrations-new {
+  .home-map {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+  }
+}
+body.sessions.new.sessions-new {
+  .home-map {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+  }
+  .auth-container {
+    width: 350px;
+  }
+}
+
+body.registrations.edit.registrations-edit {
+  .home-map {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+  }
+  .gb-avatar {
+    margin: 0 0 10px;
+  }
+}
+
+.form-actions {
+  display: flex;
+  justify-content: space-around;
+  align-items: center;
+}
+
+.edit-registration-container {
+  display: flex;
+  justify-content: space-around;
+  align-items: center;
+}
+
+.two-col-under-1366 {
+  display: block;
+}
+
+@media (max-width: 1366px) {
+  .two-col-under-1366 {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 1rem;
+  }
+}
+
+.brand-box {
+  display: inline-block;
+  background: #20c997;
+  color: #fff;
+  font-weight: 700;
+  font-size: 20px;
+  padding: 8px 20px;
+  border-radius: 8px;
+}

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -2,8 +2,8 @@ class ApplicationController < ActionController::Base
   before_action :configure_permitted_parameters, if: :devise_controller?
   def configure_permitted_parameters
     # For additional fields in app/views/devise/registrations/new.html.erb
-    devise_parameter_sanitizer.permit(:sign_up, keys: [:pseudo, :avatar])
+    devise_parameter_sanitizer.permit(:sign_up, keys: [:pseudo, :photo])
     # For additional in app/views/devise/registrations/edit.html.erb
-    devise_parameter_sanitizer.permit(:account_update, keys: [:pseudo, :avatar])
+    devise_parameter_sanitizer.permit(:account_update, keys: [:pseudo, :photo])
   end
 end

--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -1,40 +1,64 @@
-<h2>Modifier<%= resource_name.to_s.humanize %></h2>
+<div class="container my-4">
+  <%= simple_form_for(resource, as: resource_name, url: registration_path(resource_name), html: { method: :put, multipart: true }) do |f| %>
+    <%= f.error_notification %>
 
-<%= simple_form_for(resource, as: resource_name, url: registration_path(resource_name), html: { method: :put }) do |f| %>
-  <%= f.error_notification %>
+    <div class="two-col-under-1366">
+      <div class="card p-3">
+        <% if resource.persisted? && resource.photo.attached? %>
+          <%= image_tag resource.photo, class: "gb-avatar mb-3" %>
+        <% end %>
 
-  <div class="form-inputs">
-     <% if resource.persisted? && resource.photo.attached? %>
-    <%= image_tag resource.photo, class: "gb-avatar" %>
-    <% end %>
-    <%= f.input :photo, as: :file, label: "Changer ma photo" %>
-    <%= f.input :pseudo, required: false %>
-    <%= f.input :email, required: true, autofocus: true %>
+        <div class="form-inputs">
+          <label for="photo_input" class="form-label fw-bold mb-3">Modifier mon profil</label>
+          <%= f.input :photo,
+                as: :file,
+                label: false,
+                input_html: { id: "photo_input", accept: "image/*" },
+                wrapper_html: { class: "mb-3" } %>
 
-    <% if devise_mapping.confirmable? && resource.pending_reconfirmation? %>
-      <p>En attente de confirmation pour: <%= resource.unconfirmed_email %></p>
-    <% end %>
+          <%= f.input :pseudo, required: false, wrapper_html: { class: "mb-3" } %>
+          <%= f.input :email, required: true, autofocus: true, wrapper_html: { class: "mb-3" } %>
 
-    <%= f.input :password,
-                hint: "Laisser vide si vous ne souhaitez pas le changer",
-                required: false,
-                input_html: { autocomplete: "new-password" } %>
-    <%= f.input :password_confirmation,
-                required: false,
-                input_html: { autocomplete: "new-password" } %>
-    <%= f.input :current_password,
-                hint: "Nous avons besoin de votre mot de passe actuel pour valider",
-                required: true,
-                input_html: { autocomplete: "current-password" } %>
-  </div>
+          <% if devise_mapping.confirmable? && resource.pending_reconfirmation? %>
+            <p>En attente de confirmation pour: <%= resource.unconfirmed_email %></p>
+          <% end %>
+        </div>
+      </div>
 
-  <div class="form-actions">
-    <%= f.button :submit, "Mettre à jour" %>
-  </div>
-<% end %>
+      <div class="card p-3">
+        <div class="form-inputs">
+          <%= f.input :current_password,
+                      label: "Mot de passe actuel",
+                      hint: "Nous avons besoin de votre mot de passe actuel pour valider",
+                      required: true,
+                      input_html: { autocomplete: "current-password" },
+                      wrapper_html: { class: "mb-3" } %>
 
-<h3>Supprimer mon compte</h3>
+          <p class="my-3 fw-bold">Modifier mon mot de passe</p>
 
-<div>Vous nous quittez ?<%= button_to "Supprimer mon compte", registration_path(resource_name), data: { confirm: "Êtes-vous sûr ?", turbo_confirm: "Êtes-vous sûr ?" }, method: :delete %></div>
+          <%= f.input :password,
+                      label: "Mot de passe",
+                      hint: "Laisser vide si vous ne souhaitez pas le changer",
+                      required: false,
+                      input_html: { autocomplete: "new-password" },
+                      wrapper_html: { class: "mb-3" } %>
 
-<%= link_to "Retour", :back %>
+          <%= f.input :password_confirmation,
+                      label: "Confirmer votre mot de passe",
+                      required: false,
+                      input_html: { autocomplete: "new-password" },
+                      wrapper_html: { class: "mb-3" } %>
+        </div>
+
+        <div class="form-actions d-grid d-sm-flex gap-2">
+          <%= f.button :submit, "Mettre à jour", class: "btn btn-success" %>
+          <%= button_to "Supprimer mon compte",
+                registration_path(resource_name),
+                data: { confirm: "Êtes-vous sûr ?", turbo_confirm: "Êtes-vous sûr ?" },
+                method: :delete,
+                class: "btn btn-danger" %>
+        </div>
+      </div>
+    </div>
+  <% end %>
+</div>

--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -4,6 +4,11 @@
   <%= f.error_notification %>
 
   <div class="form-inputs">
+     <% if resource.persisted? && resource.photo.attached? %>
+    <%= image_tag resource.photo, class: "gb-avatar" %>
+    <% end %>
+    <%= f.input :photo, as: :file, label: "Changer ma photo" %>
+    <%= f.input :pseudo, required: false %>
     <%= f.input :email, required: true, autofocus: true %>
 
     <% if devise_mapping.confirmable? && resource.pending_reconfirmation? %>

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -1,178 +1,32 @@
-  <div class="auth-container">
-    <div class="brand-box">GeoBattle</div>
-    <h2>Je crée mon compte</h2>
-    <%= simple_form_for(resource, as: resource_name, url: registration_path(resource_name)) do |f| %>
-      <%= f.error_notification %>
-      <div class="form-inputs">
-        <%= f.input :pseudo, required: true, autofocus: true, input_html: { autocomplete: "pseudo" } %>
-        <%= f.input :photo, as: :file, label: "Photo de profil" %>
-        <%= f.input :email, required: true, autofocus: true, input_html: { autocomplete: "email" } %>
-        <%= f.input :password, required: true, hint: ("#{@minimum_password_length} caractères minimum" if @minimum_password_length), input_html: { autocomplete: "new-password" } %>
-        <%= f.input :password_confirmation, required: true, input_html: { autocomplete: "new-password" } %>
+<div class="container my-4">
+  <div class="brand-box mb-2">GeoBattle</div>
+  <h2 class="mb-3 f-bold">Je crée mon compte</h2>
 
-    <!-- Possibilité de choisir entre sa photo perso ou un avatar avec du JS à faire
-     <%= f.input :photo, required: true, as: :file %>
+  <%= simple_form_for(resource, as: resource_name, url: registration_path(resource_name)) do |f| %>
+    <%= f.error_notification %>
 
-        <button type="button" class="btn btn-primary" data-bs-toggle="modal" data-bs-target="#exampleModal">
-        Choisissez un avatar personnalisé
-        </button>
-        <div class="modal fade" id="exampleModal" tabindex="-1" aria-labelledby="exampleModalLabel" aria-hidden="true">
-          <div class="modal-dialog">
-            <div class="modal-content">
-              <div class="modal-header">
-                <h1 class="modal-title fs-5" id="exampleModalLabel">Choisissez votre avatar</h1>
-                <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
-              </div>
-              <div class="modal-body">
-                <div class="container-fluid">
-                  <div class="row">
-                    <div class="col-md-4 ms-auto">
-                      <input type="checkbox" name='user[avatar]' value="https://res.cloudinary.com/dl1ywiiiu/image/upload/v1756375464/Avatar_F_1_ovljm4.png" id="avatar1"/><label for="avatar1"></label>
-                    </div>
-                    <div class="col-md-4 ms-auto">
-                      <input type="checkbox" name='user[avatar]' value="https://res.cloudinary.com/dl1ywiiiu/image/upload/v1756392132/Avatar_F_4_whsizu.png" id="avatar2"/><label for="avatar2"></label>
-                    </div>
-                    <div class="col-md-4 ms-auto">
-                      <input type="checkbox" name='user[avatar]' value="https://res.cloudinary.com/dl1ywiiiu/image/upload/v1756375459/Avatar_H_1_erb2fz.png" id="avatar3"/><label for="avatar3"></label>
-                    </div>
-                  </div>
-                  <div class="row">
-                    <div class="col-md-4 ms-auto">
-                      <input type="checkbox" name='user[avatar]' value="https://res.cloudinary.com/dl1ywiiiu/image/upload/v1756375464/Avatar_F_1_ovljm4.png" id="avatar1"/><label for="avatar1"></label>
-                    </div>
-                    <div class="col-md-4 ms-auto">
-                      <input type="checkbox" name='user[avatar]' value="https://res.cloudinary.com/dl1ywiiiu/image/upload/v1756392132/Avatar_F_4_whsizu.png" id="avatar2"/><label for="avatar2"></label>
-                    </div>
-                    <div class="col-md-4 ms-auto">
-                      <input type="checkbox" name='user[avatar]' value="https://res.cloudinary.com/dl1ywiiiu/image/upload/v1756375459/Avatar_H_1_erb2fz.png" id="avatar3"/><label for="avatar3"></label>
-                    </div>
-                  </div>
-                  <div class="row">
-                    <div class="col-md-4 ms-auto">
-                      <input type="checkbox" name='user[avatar]' value="https://res.cloudinary.com/dl1ywiiiu/image/upload/v1756375464/Avatar_F_1_ovljm4.png" id="avatar1"/><label for="avatar1"></label>
-                    </div>
-                    <div class="col-md-4 ms-auto">
-                      <input type="checkbox" name='user[avatar]' value="https://res.cloudinary.com/dl1ywiiiu/image/upload/v1756392132/Avatar_F_4_whsizu.png" id="avatar2"/><label for="avatar2"></label>
-                    </div>
-                    <div class="col-md-4 ms-auto">
-                      <input type="checkbox" name='user[avatar]' value="https://res.cloudinary.com/dl1ywiiiu/image/upload/v1756375459/Avatar_H_1_erb2fz.png" id="avatar3"/><label for="avatar3"></label>
-                    </div>
-                  </div>
-                  <div class="row">
-                   <div class="col-md-4 ms-auto">
-                      <input type="checkbox" name='user[avatar]' value="https://res.cloudinary.com/dl1ywiiiu/image/upload/v1756375464/Avatar_F_1_ovljm4.png" id="avatar1"/><label for="avatar1"></label>
-                    </div>
-                    <div class="col-md-4 ms-auto">
-                      <input type="checkbox" name='user[avatar]' value="https://res.cloudinary.com/dl1ywiiiu/image/upload/v1756392132/Avatar_F_4_whsizu.png" id="avatar2"/><label for="avatar2"></label>
-                    </div>
-                    <div class="col-md-4 ms-auto">
-                      <input type="checkbox" name='user[avatar]' value="https://res.cloudinary.com/dl1ywiiiu/image/upload/v1756375459/Avatar_H_1_erb2fz.png" id="avatar3"/><label for="avatar3"></label>
-                    </div>
-                  </div>
-                </div>
-              </div>
-              <div class="modal-footer">
-                <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Close</button>
-                <button type="button" class="btn btn-primary">Save changes</button>
-              </div>
-            </div>
-          </div>
-        </div> -->
+    <div class="two-col-under-1366">
+      <div class="card p-3">
+        <div class="form-inputs">
+          <%= f.input :pseudo, required: true, autofocus: true, input_html: { autocomplete: "pseudo" }, wrapper_html: { class: "mb-3" } %>
+          <%= f.input :photo, as: :file, label: "Photo de profil", wrapper_html: { class: "mb-3" } %>
+          <%= f.input :email, required: true, input_html: { autocomplete: "email" }, wrapper_html: { class: "mb-3" } %>
+        </div>
       </div>
-      <div class="form-actions">
-        <%= f.button :submit, "S'enregistrer", class: "btn" %>
+
+      <div class="card p-3">
+        <div class="form-inputs">
+          <%= f.input :password, required: true, hint: ("#{@minimum_password_length} caractères minimum" if @minimum_password_length), input_html: { autocomplete: "new-password" }, wrapper_html: { class: "mb-3" } %>
+          <%= f.input :password_confirmation, required: true, input_html: { autocomplete: "new-password" }, wrapper_html: { class: "mb-3" } %>
+        </div>
+        <div class="form-actions d-grid d-sm-flex gap-2">
+          <%= f.button :submit, "S'enregistrer", class: "btn btn-success" %>
+        </div>
       </div>
-    <% end %>
-    <div class="links">
-      <%= render "devise/shared/links" %>
     </div>
+  <% end %>
+
+  <div class="links mt-3">
+    <%= render "devise/shared/links", class: "btn btn-primary" %>
   </div>
-  <style>
-
-  .auth-container {
-    max-width: 400px;
-    margin: 80px auto;
-    padding: 30px;
-    background: #fff;
-    border-radius: 10px;
-    box-shadow: 0 4px 12px rgba(0,0,0,0.1);
-    text-align: center;
-    font-family: sans-serif;
-  }
-  .brand-box {
-    display: inline-block;
-    background: #20C997;
-    color: #fff;
-    font-weight: bold;
-    font-size: 20px;
-    padding: 8px 20px;
-    border-radius: 8px;
-    margin-bottom: 20px;
-  }
-  .auth-container h2 {
-    margin-bottom: 20px;
-  }
-  .form-inputs {
-    text-align: left;
-    margin-bottom: 20px;
-  }
-  input[type="email"],
-  input[type="password"],
-  input[type="text"] {
-    width: 100%;
-    padding: 10px;
-    margin: 6px 0;
-    border: 1px solid #ccc;
-    border-radius: 6px;
-  }
-  .btn {
-    width: 100%;
-    padding: 12px;
-    border: none;
-    border-radius: 6px;
-    background: #20C997;
-    color: white;
-    font-weight: bold;
-    cursor: pointer;
-  }
-  .btn:hover {
-    background: #198F6E;
-  }
-  .links {
-    margin-top: 15px;
-    font-size: 14px;
-  }
-
-  input[type=checkbox] {
-  display: none;
-  }
-
-  input#avatar1[type=checkbox]+label {
-    background-image: url(https://res.cloudinary.com/dl1ywiiiu/image/upload/v1756375464/Avatar_F_1_ovljm4.png);
-    background-position: center;
-    height: 100px;
-    width: 100px;
-    display: inline-block;
-    padding: 0 0 0 0px;
-    border-radius: 50%;
-  }
-
-  input#avatar2[type=checkbox]+label {
-    background-image: url(https://res.cloudinary.com/dl1ywiiiu/image/upload/v1756392132/Avatar_F_4_whsizu.png);
-    background-position: center;
-    height: 100px;
-    width: 100px;
-    display: inline-block;
-    padding: 0 0 0 0px;
-    border-radius: 50%;
-  }
-
-  input#avatar1:checked+label {
-    border: 3px solid gold;
-  }
-
-  input#avatar2:checked+label {
-    border: 3px solid gold;
-  }
-  </style>
 </div>

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -5,6 +5,7 @@
       <%= f.error_notification %>
       <div class="form-inputs">
         <%= f.input :pseudo, required: true, autofocus: true, input_html: { autocomplete: "pseudo" } %>
+        <%= f.input :photo, as: :file, label: "Photo de profil" %>
         <%= f.input :email, required: true, autofocus: true, input_html: { autocomplete: "email" } %>
         <%= f.input :password, required: true, hint: ("#{@minimum_password_length} caractères minimum" if @minimum_password_length), input_html: { autocomplete: "new-password" } %>
         <%= f.input :password_confirmation, required: true, input_html: { autocomplete: "new-password" } %>

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -10,7 +10,7 @@
       </div>
 
       <div class="form-actions">
-        <%= f.button :submit, "Se connecter", class: "btn" %>
+        <%= f.button :submit, "Se connecter", class: "btn btn-primary" %>
       </div>
     <% end %>
 
@@ -24,7 +24,7 @@
     max-width: 400px;
     margin: 80px auto;
     padding: 30px;
-    background: #fff;
+    background-color: #ffec9a;
     border-radius: 10px;
     box-shadow: 0 4px 12px rgba(0,0,0,0.1);
     text-align: center;
@@ -65,14 +65,9 @@
     padding: 12px;
     border: none;
     border-radius: 6px;
-    background: #20c997;
     color: white;
     font-weight: bold;
     cursor: pointer;
-  }
-
-  .btn:hover {
-    background: #198f6e;
   }
 
   .links {

--- a/app/views/devise/shared/_links.html.erb
+++ b/app/views/devise/shared/_links.html.erb
@@ -1,5 +1,5 @@
 <%- if controller_name != 'sessions' %>
-  <%= link_to "Se connecter", new_session_path(resource_name) %><br />
+  <%= link_to "Se connecter", new_session_path(resource_name), class: local_assigns[:class] %><br />
 <% end %>
 
 <%- if devise_mapping.registerable? && controller_name != 'registrations' %>

--- a/app/views/pages/about.html.erb
+++ b/app/views/pages/about.html.erb
@@ -7,7 +7,11 @@
   </div>
 
   <div class="gb-sidebar__avatar">
-    <%= image_tag "avatar3.png", alt: "Profil", class: "gb-avatar" %>
+    <% if current_user&.photo&.attached? %>
+      <%= image_tag current_user.photo, alt: "Profil", class: "gb-avatar" %>
+    <% else %>
+      <%= image_tag "avatar3.png", alt: "Profil", class: "gb-avatar" %>
+    <% end %>
   </div>
 
   <nav class="gb-sidebar__menu">

--- a/app/views/pages/profile.html.erb
+++ b/app/views/pages/profile.html.erb
@@ -7,7 +7,11 @@
   </div>
 
   <div class="gb-sidebar__avatar">
-    <%= image_tag "avatar3.png", alt: "Profil", class: "gb-avatar" %>
+    <% if current_user&.photo&.attached? %>
+      <%= image_tag current_user.photo, alt: "Profil", class: "gb-avatar" %>
+    <% else %>
+      <%= image_tag "avatar3.png", alt: "Profil", class: "gb-avatar" %>
+    <% end %>
   </div>
 
   <nav class="gb-sidebar__menu">
@@ -47,25 +51,37 @@
   <div class="profile-container">
     <div class="profile-card">
       <div class="profile-avatar-wrap">
-        <%= image_tag "avatar3.png", alt: "Avatar", class: "profile-avatar" %>
-        <i class="fa-solid fa-pen-to-square edit-icon avatar-edit"></i>
+        <% if current_user&.photo&.attached? %>
+          <%= image_tag current_user.photo, alt: "Avatar", class: "profile-avatar" %>
+        <% else %>
+          <%= image_tag "avatar3.png", alt: "Avatar", class: "profile-avatar" %>
+        <% end %>
+        <%= link_to edit_user_registration_path(anchor: 'user-avatar'), class: 'edit-link', title: 'Modifier mon avatar' do %>
+          <i class="fa-solid fa-pen-to-square edit-icon avatar-edit"></i>
+        <% end %>
       </div>
 
       <hr class="profile-sep">
 
       <div class="profile-field profile-field--name">
-        <span class="profile-name">Cauchix</span>
-        <i class="fa-solid fa-pen-to-square edit-icon"></i>
+        <span class="profile-name"><%= current_user.pseudo %></span>
+        <%= link_to edit_user_registration_path(anchor: 'user-pseudo'), class: 'edit-link', title: 'Modifier mon pseudo' do %>
+          <i class="fa-solid fa-pen-to-square edit-icon"></i>
+        <% end %>
       </div>
 
       <div class="profile-field">
         <span class="profile-label">Mot de passe</span>
-        <i class="fa-solid fa-pen-to-square edit-icon"></i>
+        <%= link_to edit_user_registration_path(anchor: 'user-password'), class: 'edit-link', title: 'Modifier mon mot de passe' do %>
+          <i class="fa-solid fa-pen-to-square edit-icon"></i>
+        <% end %>
       </div>
 
       <div class="profile-field">
         <span class="profile-label">Email</span>
-        <i class="fa-solid fa-pen-to-square edit-icon"></i>
+        <%= link_to edit_user_registration_path(anchor: 'user-email'), class: 'edit-link', title: 'Modifier mon email' do %>
+          <i class="fa-solid fa-pen-to-square edit-icon"></i>
+        <% end %>
       </div>
 
       <hr class="profile-sep">

--- a/app/views/pages/rewards.html.erb
+++ b/app/views/pages/rewards.html.erb
@@ -7,7 +7,11 @@
   </div>
 
   <div class="gb-sidebar__avatar">
-    <%= image_tag "avatar3.png", alt: "Profil", class: "gb-avatar" %>
+    <% if current_user&.photo&.attached? %>
+      <%= image_tag current_user.photo, alt: "Profil", class: "gb-avatar" %>
+    <% else %>
+      <%= image_tag "avatar3.png", alt: "Profil", class: "gb-avatar" %>
+    <% end %>
   </div>
 
   <nav class="gb-sidebar__menu">

--- a/app/views/pages/stats.html.erb
+++ b/app/views/pages/stats.html.erb
@@ -7,7 +7,11 @@
   </div>
 
   <div class="gb-sidebar__avatar">
-    <%= image_tag "avatar3.png", alt: "Profil", class: "gb-avatar" %>
+    <% if current_user&.photo&.attached? %>
+      <%= image_tag current_user.photo, alt: "Profil", class: "gb-avatar" %>
+    <% else %>
+      <%= image_tag "avatar3.png", alt: "Profil", class: "gb-avatar" %>
+    <% end %>
   </div>
 
   <nav class="gb-sidebar__menu">


### PR DESCRIPTION
Changes

  - UI/Styles
      - Add app/assets/stylesheets/pages/_registration.scss and wire it in application.scss.
      - Restyle Devise views: sessions/new, registrations/new, registrations/edit.
      - Tweak shared links and several static pages for consistency.
  - Behavior
      - Update app/controllers/application_controller.rb to support new profile fields (e.g.,
  permitting/handling additional attributes).
  - Files touched
      - New: app/assets/stylesheets/pages/_registration.scss
      - Modified: application.scss, application_controller.rb, Devise views, and several pages.
  - Diff stats
      - 11 files changed, 189 insertions(+), 219 deletions(−)

  Why

  - Improve clarity and consistency of the auth pages.
  - Let users manage core profile details directly (photo, pseudo/username, email, password).
  - Centralize and isolate registration/auth styles for easier maintenance.

  Testing

  - Sign up: verify layout, validation, error states.
  - Sign in: verify form works, error messages render with new styles.
  - Profile edit:
      - Update profile photo.
      - Change pseudo/username.
      - Update email and confirm flow.
      - Change password and re-authenticate.
  - Cross-check links in devise/shared/_links.html.erb.
  - Visual check across breakpoints to ensure responsive layout.

  Notes

  - If Devise strong parameters are used, confirm permitted attributes include :pseudo and any
  file attachment key for the profile photo.

  Checklist

  - [ ] All updated views render without layout regressions
  - [ ] New styles are imported and scoped correctly
  - [ ] Profile updates persist and reflect in UI
  - [ ] No console or server errors in happy paths